### PR TITLE
Delete buildout.cfg

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,4 +1,0 @@
-[buildout]
-extends =
-    test-plone-4.3.x.cfg
-    https://raw.github.com/4teamwork/ftw-buildouts/master/plone-development.cfg


### PR DESCRIPTION
Developers should symlink `development.cfg` to `buildout.cfg` which is not possible if there already is a `buildout.cfg` .
