### PR TITLE
support chameleon by defining template on class scope.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 1.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix chameleon support. [jone]
 
 
 1.0.0 (2016-09-26)

--- a/ftw/contentnav/viewlets/contentnavlisting.py
+++ b/ftw/contentnav/viewlets/contentnavlisting.py
@@ -9,8 +9,7 @@ from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 class ContentNavListingViewlet(ViewletBase):
     """Lists content by categories"""
 
-    def render(self):
-        return ViewPageTemplateFile('contentnavlisting.pt')(self)
+    render = ViewPageTemplateFile('contentnavlisting.pt')
 
     def available(self):
         return bool(self.get_content())


### PR DESCRIPTION
In order for chameleon to be able to cache the compiled page template file, the page template file definition should be on class scope.

@maethu 
/cc @elioschmutz FYI
